### PR TITLE
Fix lat long dependency static ip

### DIFF
--- a/examples/add_static_with geooverride_and_gre_tunnel.py
+++ b/examples/add_static_with geooverride_and_gre_tunnel.py
@@ -6,6 +6,9 @@ import zscaler_python_sdk
 def main():
 
 	static_ipv4       = 'X.X.X.X'  # Your public static IP address 
+	geoOverride       = True # If wanting to manually configure IP GeoLocation
+	latitude          = '47.608013'
+	longitude         = '-122.335167'
 	location_name     = 'sjc_sdwan_1 (San Jose, CA)'
 
 
@@ -19,7 +22,10 @@ def main():
 	# Create static IP address
 	print("\n\n ##########  CREATE STATIC IP ##########\n\n")
 	res = z.create_static_ip(
-		static_ipv4
+		static_ipv4,
+		latitude, 
+		longitude,
+  		geoOverride
 	)
 
 	# Extract Static IP ID. 
@@ -28,7 +34,11 @@ def main():
 
 	# Get closest DC VIPs by Source IP
 	print("\n\n ##########  GET GRE VIPS BY SOURCE IP  ##########\n\n")	
-	res = z.get_gre_vips(static_ipv4)
+	res = z.get_gre_vips(
+    	static_ipv4,
+    	latitude,
+     	longitude
+	)
 
 	# Extract Primary and Secondary VIPs
 	print("\n\n ##########  EXTRACTING PRIMARY VIP ID  ##########\n\n")

--- a/examples/add_static_with_geooverride_and_gre_tunnel.py
+++ b/examples/add_static_with_geooverride_and_gre_tunnel.py
@@ -23,9 +23,9 @@ def main():
 	print("\n\n ##########  CREATE STATIC IP ##########\n\n")
 	res = z.create_static_ip(
 		static_ipv4,
-		latitude, 
-		longitude,
-  		geoOverride
+		latitude=latitude, 
+		longitude=longitude,
+  		geoOverride=geoOverride
 	)
 
 	# Extract Static IP ID. 
@@ -36,8 +36,8 @@ def main():
 	print("\n\n ##########  GET GRE VIPS BY SOURCE IP  ##########\n\n")	
 	res = z.get_gre_vips(
     	static_ipv4,
-    	latitude,
-     	longitude
+    	latitude=latitude,
+     	longitude=longitude
 	)
 
 	# Extract Primary and Secondary VIPs

--- a/zscaler_python_sdk/Gre.py
+++ b/zscaler_python_sdk/Gre.py
@@ -139,7 +139,7 @@ class Gre(object):
                 )
         
         else:
-            uri = '{}api/v1/vips/group:ByDatacenter?sourceIp={}'.format(
+            uri = '{}api/v1/vips/groupByDatacenter?sourceIp={}'.format(
                 self.api_url,
                 source_ip
                 )

--- a/zscaler_python_sdk/Gre.py
+++ b/zscaler_python_sdk/Gre.py
@@ -32,30 +32,42 @@ class Gre(object):
         return res
 
         
-    def create_static_ip(self, static_ip, latitude, longitude):
+    def create_static_ip(self, static_ip, **data):
+        
+        latitude = data.get(latitude)
+        longitude = data.get(longitude)
+        geoOverride = data.get(geoOverride)
         
         uri = self.api_url + 'api/v1/staticIP'
     
         if not static_ip:
             if self.debug:
                 logging.error("ERROR: {}".format("No IP Address Provided"))
-            return 'No IP Address Provided'        
+                return 'No IP Address Provided'        
 
-        if not latitude:
-            if self.debug:
-                logging.error("ERROR: {}".format("No Latitude Provided"))
-            return 'No Latitude Provided'   
+        # To manually set geolocation of static IP the geoOverride parameter must be passed
+        # if not, then lat / long will be ignored.
+        if geoOverride == True:
+            if not latitude:
+                if self.debug:
+                    logging.error("ERROR: {}".format("No Latitude Provided"))
+                return 'No Latitude Provided'   
 
-        if not longitude:
-            if self.debug:
-                logging.error("ERROR: {}".format("No Longitude Provided"))
-            return 'No Longitude Provided'   
+            if not longitude:
+                if self.debug:
+                    logging.error("ERROR: {}".format("No Longitude Provided"))
+                return 'No Longitude Provided'   
     
-        body = {
-            'ipAddress' : static_ip,
-            'latitude'  : latitude, 
-            'longitude' : longitude
-        }
+            body = {
+                'ipAddress' : static_ip,
+                'latitude'  : latitude, 
+                'longitude' : longitude,
+                'geoOverride': geoOverride
+            }
+        else:
+            body = {
+                'ipAddress' : static_ip
+            }
 
         res = self._perform_post_request(
             uri,
@@ -107,12 +119,30 @@ class Gre(object):
         return res
 
 
-    def get_gre_vips(self, source_ip):
+    def get_gre_vips(self, source_ip, **data):
 
-        uri = '{}api/v1/vips/groupByDatacenter?sourceIp={}'.format(
-            self.api_url,
-            source_ip
-            )
+        latitude = data.get(latitude)
+        longitude = data.get(longitude)
+
+        if (latitude or longitude) and not (latitude and longitude):
+            if self.debug:
+                logging.error("ERROR: {}".format("Must include both Lat and Long for proximity lookup"))
+                return 'Must include both Lat and Long for proximity lookup'        
+
+        #When using geoOverride you must pass the coordinates in order to get the proper lookups for the closest DC's
+        if (latitude and longitude):
+            uri = '{}api/v1/vips/group:ByDatacenter?sourceIp={}&latitude={}&longitude={}'.format(
+                self.api_url,
+                source_ip,
+                latitude,
+                longitude
+                )
+        
+        else:
+            uri = '{}api/v1/vips/group:ByDatacenter?sourceIp={}'.format(
+                self.api_url,
+                source_ip
+                )
 
         res = self._perform_get_request(
             uri,

--- a/zscaler_python_sdk/Gre.py
+++ b/zscaler_python_sdk/Gre.py
@@ -131,7 +131,7 @@ class Gre(object):
 
         #When using geoOverride you must pass the coordinates in order to get the proper lookups for the closest DC's
         if (latitude and longitude):
-            uri = '{}api/v1/vips/group:ByDatacenter?sourceIp={}&latitude={}&longitude={}'.format(
+            uri = '{}api/v1/vips/groupByDatacenter?sourceIp={}&latitude={}&longitude={}'.format(
                 self.api_url,
                 source_ip,
                 latitude,

--- a/zscaler_python_sdk/Gre.py
+++ b/zscaler_python_sdk/Gre.py
@@ -34,9 +34,9 @@ class Gre(object):
         
     def create_static_ip(self, static_ip, **data):
         
-        latitude = data.get(latitude)
-        longitude = data.get(longitude)
-        geoOverride = data.get(geoOverride)
+        latitude = data.get('latitude')
+        longitude = data.get('longitude')
+        geoOverride = data.get('geoOverride')
         
         uri = self.api_url + 'api/v1/staticIP'
     
@@ -121,8 +121,8 @@ class Gre(object):
 
     def get_gre_vips(self, source_ip, **data):
 
-        latitude = data.get(latitude)
-        longitude = data.get(longitude)
+        latitude = data.get('latitude')
+        longitude = data.get('longitude')
 
         if (latitude or longitude) and not (latitude and longitude):
             if self.debug:


### PR DESCRIPTION
Fixed the GRE tunnel example, removing the Lat / Long as a requirement and created a new example using the override flag to enable manual configuration of lat / long for a static IP.

As part of this I updated the create_static_ip and get_gre_vips functions to support optionally passing lat / long parameters.