### PR TITLE
Update for Python 3.13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Python SDK for Zscaler Internet Access (ZIA).  This client library is designed to support the ZIA [API](https://help.zscaler.com/zia/zia-api) and ZIA [Partner API](https://help.zscaler.com/zia/sd-wan-api-integration) (aka "SD-WAN" API) in ZIA 6.1 or newer.  All ZIA API references can be found here [[LINK](https://help.zscaler.com/zia/zia-api)].  **PLEASE READ THE DOCUMENTATION BEFORE CONTACTING ZSCALER**
 
-This SDK has been developed mainly using Python 3.8.2 on macOS (10.15.7) and Ubuntu 18.04.1 LTS (Bionic Beaver).  
+This SDK has been tested with Python 3.13.3 and is compatible with Python 3.8 and newer.
 
 **NOTE:** This repository will experience frequent updates.  To minimize breakage, public method names will not change.  If you run into any defects, please open issues [[HERE.](https://github.com/eparra/zscaler-python-sdk/issues)]   
 
@@ -38,21 +38,14 @@ $ git clone https://github.com/eparra/zscaler-python-sdk.git
 $ cd zscaler-python-sdk/
 ```
 
-5) Install SDK requirements
+5) Install SDK
 
 ```
-$ pip3 install -r requirements.txt
+$ pip install .
 ...
 ```
 
-6) Install SDK
-
-```
-$ python3 setup.py install
-...
-```
-
-7) Check out examples
+6) Check out examples
 
 ```
 $ ls examples/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.32.0
+requests>=2.32.0

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 
 import os
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 from zscaler_python_sdk import __version__
 
@@ -13,8 +10,9 @@ from zscaler_python_sdk import __version__
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     long_description = readme.read()
 
-setup(name='zscaler_python_sdk',
-      python_requires='>3.8.2',
+setup(
+      name='zscaler_python_sdk',
+      python_requires='>=3.8',
       version=__version__,
       description='Python Interface to Zscaler API',
       long_description=long_description,
@@ -24,7 +22,14 @@ setup(name='zscaler_python_sdk',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: MIT License',
           'Operating System :: OS Independent',
-          'Programming Language :: Python :: 3.8.2',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3 :: Only',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
+          'Programming Language :: Python :: 3.13',
           'Natural Language :: English',
       ],
       keywords='zscaler python',
@@ -34,7 +39,7 @@ setup(name='zscaler_python_sdk',
       maintainer_email='NO EMAIL',
       url='https://github.com/eparra/zscaler-python-sdk/',
       license='MIT',
-      packages=['zscaler_python_sdk'],
-      install_requires=['requests>=2.25.1'],
+      packages=find_packages(),
+      install_requires=['requests>=2.32.0'],
       zip_safe=False
 )

--- a/zscaler_python_sdk/__init__.py
+++ b/zscaler_python_sdk/__init__.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 
-__version_tuple__ = (0,0,6)
+__version_tuple__ = (0,0,7)
 __version__       = '.'.join(map(str, __version_tuple__))
 __email__         = 'NO EMAIL'
 __author__        = "Eddie Parra <{0}>".format(__email__)


### PR DESCRIPTION
## Summary
- add `pyproject.toml` build settings
- update `setup.py` packaging metadata
- relax version pin in requirements
- bump SDK version to 0.0.7
- document Python 3.13 support and simplified install

## Testing
- `pip install -e .` *(fails: Could not fetch build dependencies)*