### PR TITLE
Fix typos in Auth cloud error message

### DIFF
--- a/zscaler_python_sdk/Auth.py
+++ b/zscaler_python_sdk/Auth.py
@@ -97,6 +97,6 @@ class Auth(object):
 			if self.debug:
 				logging.debug("CLOUD SET TO: {}".format(cloud))
 		else:
-			if self.debug:
-				logging.debug("CLOUD ERROD: {}".format("Unknwon Cloud"))				
-			return "Unknwon Cloud"		
+                        if self.debug:
+                                logging.debug("CLOUD ERROR: {}".format("Unknown Cloud"))
+                        return "Unknown Cloud"


### PR DESCRIPTION
## Summary
- correct misspellings for cloud error message in `Auth.set_cloud`

## Testing
- `python -m compileall -q zscaler_python_sdk`
