### PR TITLE
Update README acknowledgment header

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you have bugs or other issues specifically pertaining to this library, file t
 * https://help.zscaler.com/zia/zia-api/api-developer-reference-guide
 * https://help.zscaler.com/zia/sd-wan-api-integration
 
-## References
+## Acknowledgments
 
 Thanks to:
 


### PR DESCRIPTION
## Summary
- rename second `References` heading to `Acknowledgments`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zscaler_python_sdk')*