### PR TITLE
Introduce async client skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ Thanks to:
 * [Sofian Halim](https://www.linkedin.com/in/sofian-halim-9237b25/)
 * [Lidor Pergament](https://www.linkedin.com/in/lidorp/)
 * [Paul Abbott](https://www.linkedin.com/in/paul-abbott-4b014/)
+
+## Async Client (v2)
+
+A new asynchronous client is provided under `zscaler_python_sdk.v2`. It uses `httpx` and dataclasses for configuration.
+
+Example:
+```python
+from zscaler_python_sdk.v2 import ZscalerConfig, ZscalerAsyncClient
+
+config = ZscalerConfig(username="user", password="pass", api_key="apikey")
+client = ZscalerAsyncClient(config)
+# await client.get("api/v1/some/resource")
+```
+

--- a/examples/test_partner_credentials.py
+++ b/examples/test_partner_credentials.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
 
+"""Example script used for manual testing.
+
+The file name starts with ``test_`` so pytest tries to collect it. We skip it
+during automated test runs.
+"""
+
+import pytest
+
+pytest.skip("example only", allow_module_level=True)
+
 import zscaler_python_sdk
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.32.0
 pytest>=8.1.1
+httpx>=0.27.0

--- a/tests/test_v2_config.py
+++ b/tests/test_v2_config.py
@@ -1,0 +1,24 @@
+import sys
+import types
+import os
+
+# Ensure the package root is on the import path so the SDK can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide a minimal stub for the 'httpx' module which is required when importing
+# the async client but is not available in the test environment.
+httpx_stub = types.ModuleType('httpx')
+httpx_stub.AsyncClient = lambda *args, **kwargs: None
+sys.modules.setdefault('httpx', httpx_stub)
+
+from zscaler_python_sdk.v2 import ZscalerConfig
+
+
+def test_base_url_mapping():
+    cfg = ZscalerConfig(username='u', password='p', api_key='k', cloud='zscloud')
+    assert cfg.get_base_url() == 'https://zsapi.zscloud.net/'
+
+
+def test_base_url_custom():
+    cfg = ZscalerConfig(username='u', password='p', api_key='k', base_url='https://custom/')
+    assert cfg.get_base_url() == 'https://custom/'

--- a/zscaler_python_sdk/v2/__init__.py
+++ b/zscaler_python_sdk/v2/__init__.py
@@ -1,0 +1,6 @@
+"""Async v2 client for the Zscaler SDK."""
+
+from .config import ZscalerConfig
+from .client import ZscalerAsyncClient
+
+__all__ = ["ZscalerConfig", "ZscalerAsyncClient"]

--- a/zscaler_python_sdk/v2/client.py
+++ b/zscaler_python_sdk/v2/client.py
@@ -1,0 +1,26 @@
+import httpx
+from .config import ZscalerConfig
+
+class ZscalerAsyncClient:
+    """Async client using httpx."""
+
+    def __init__(self, config: ZscalerConfig):
+        self.config = config
+        self._session = httpx.AsyncClient()
+
+    async def close(self):
+        await self._session.aclose()
+
+    async def request(self, method: str, path: str, **kwargs):
+        url = self.config.get_base_url().rstrip('/') + '/' + path.lstrip('/')
+        headers = kwargs.pop('headers', {})
+        headers['User-Agent'] = 'ZscalerSDK/2.0'
+        resp = await self._session.request(method, url, headers=headers, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    async def get(self, path: str, **kwargs):
+        return await self.request('GET', path, **kwargs)
+
+    async def post(self, path: str, json=None, **kwargs):
+        return await self.request('POST', path, json=json, **kwargs)

--- a/zscaler_python_sdk/v2/config.py
+++ b/zscaler_python_sdk/v2/config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class ZscalerConfig:
+    """Configuration for the async Zscaler client."""
+    username: str
+    password: str
+    api_key: str
+    cloud: str = "zscaler"
+    base_url: Optional[str] = None
+
+    def get_base_url(self) -> str:
+        """Return the base URL for API requests."""
+        if self.base_url:
+            return self.base_url
+        # Map common cloud names to API hostnames
+        clouds = {
+            'zscaler': 'https://zsapi.zscaler.net/',
+            'zscloud': 'https://zsapi.zscloud.net/',
+            'govcloud': 'https://admin.zscalergov.net/',
+        }
+        return clouds.get(self.cloud, self.cloud)


### PR DESCRIPTION
## Summary
- create `zscaler_python_sdk.v2` package with dataclass config and `httpx` based async client
- document new async client in `README`
- add requirement on `httpx`
- skip example test file during pytest collection
- test config helper for base URL resolution

## Testing
- `pytest -q`
